### PR TITLE
fix: use separate autolabeler action for release-drafter v7

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,18 +4,29 @@ on:
   push:
     branches:
       - main
+  # pull_request event is required only for autolabeler
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
+  autolabeler:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   update_release_draft:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
         with:
-          commitish: main
-          # main への push (マージ) 時のみリリースを公開し、PR時は下書き更新のみにする
-          publish: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-
+          publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- release-drafter v7ではdrafterとautolabelerが別アクションに分離された
- PR時: `release-drafter/release-drafter/autolabeler@v7` でラベル付与のみ
- push時: `release-drafter/release-drafter@v7` でリリース作成のみ
- `permissions` を明示的に設定

## Test plan
- [ ] PRイベントでautolabelerジョブが成功すること
- [ ] mainへのpush時にリリースが正しく作成されること