### PR TITLE
開発用検索エンジンを OpenSearch 2.18.0 に切り替え

### DIFF
--- a/devenv/elasticsearch/Dockerfile
+++ b/devenv/elasticsearch/Dockerfile
@@ -1,4 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:9.3.3
-RUN elasticsearch-plugin install analysis-kuromoji
-RUN elasticsearch-plugin install analysis-icu
-
+FROM opensearchproject/opensearch:2.18.0
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-kuromoji
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-icu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,16 +83,15 @@ services:
       context: .
       dockerfile: ./devenv/elasticsearch/Dockerfile
     volumes:
-      - elasticsearch:/usr/share/elasticsearch/data
+      - elasticsearch:/usr/share/opensearch/data
     environment:
       http.host: "0.0.0.0"
       http.port: "9200"
       discovery.type: "single-node"
-      ES_JAVA_OPTS: '-Xms256m -Xmx256m'
+      OPENSEARCH_JAVA_OPTS: '-Xms256m -Xmx256m'
       DISABLE_INSTALL_DEMO_CONFIG: true
       node.name: "elasticsearch"
       DISABLE_SECURITY_PLUGIN: true
-      xpack.security.enabled: false
       #entrypoint: >
       #  bash -c "bin/elasticsearch-plugin install analysis-kuromoji &&
       #  bin/elasticsearch-plugin install analysis-icu &&


### PR DESCRIPTION
## 概要

開発環境の検索エンジン (devenv) を Elasticsearch 9.3.3 から OpenSearch 2.18.0 へ切り替えます。

アプリ側は `opensearch-ruby` + `searchkick` 6.1 を使用しており、`config/initializers/searchkick.rb` も `OpenSearch::Client.new` を直叩きしている一方、`devenv/elasticsearch/Dockerfile` が ES 9.3.3 を起動していたため `OpenSearch::UnsupportedProductError` でローカルテストが全滅していました。

## 変更点

- `devenv/elasticsearch/Dockerfile`
  - FROM を `opensearchproject/opensearch:2.18.0` に変更
  - プラグインインストールを `opensearch-plugin install --batch analysis-kuromoji / analysis-icu` に置き換え
- `docker-compose.yml` の `elasticsearch` サービス
  - ボリュームマウントを `/usr/share/opensearch/data` に修正
  - `ES_JAVA_OPTS` → `OPENSEARCH_JAVA_OPTS`
  - OpenSearch が未知設定で起動失敗する `xpack.security.enabled` を削除

## 動作確認

- `docker compose up -d db elasticsearch` で OpenSearch コンテナが cluster status `green` で起動
- `bundle exec rspec` → 44 examples, 0 failures, 1 pending (カバレッジ 97.39%)

## 補足

ディレクトリ名・サービス名は互換のため `elasticsearch` を維持しています（リネームは別 PR で検討）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 検索基盤のローカル開発環境を更新し、より新しい互換イメージを使うようになりました。
  * プラグインの導入方法を更新し、セットアップ手順を整理しました。
  * データ保存先と JVM メモリ設定の指定方法を最新の構成に合わせました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->