### PR TITLE
Zed で ruby-lsp を利用できるよう設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ yarn-debug.log*
 !/app/assets/builds/.keep
 aws_credentials.txt
 .config/
+
+# ruby-lsp
+/.ruby-lsp/

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,53 @@
+{
+  "languages": {
+    "Ruby": {
+      "language_servers": ["ruby-lsp", "!solargraph", "!rubocop"],
+      "formatter": {
+        "language_server": { "name": "ruby-lsp" }
+      },
+      "format_on_save": "on",
+      "tab_size": 2
+    }
+  },
+  "lsp": {
+    "ruby-lsp": {
+      "initialization_options": {
+        "enabledFeatures": {
+          "diagnostics": true,
+          "codeActions": true,
+          "documentSymbols": true,
+          "documentHighlights": true,
+          "foldingRanges": true,
+          "selectionRanges": true,
+          "semanticHighlighting": true,
+          "formatting": true,
+          "onTypeFormatting": true,
+          "hover": true,
+          "inlayHint": true,
+          "completion": true,
+          "definition": true,
+          "signatureHelp": true,
+          "typeHierarchy": true,
+          "codeLens": true
+        },
+        "featuresConfiguration": {
+          "inlayHint": {
+            "implicitRescue": true,
+            "implicitHashValue": true
+          }
+        },
+        "formatter": "rubocop_internal",
+        "linters": ["rubocop_internal"],
+        "addonSettings": {
+          "Ruby LSP Rails": {
+            "enablePendingMigrationsPrompt": false
+          }
+        }
+      }
+    }
+  },
+  "file_types": {
+    "Ruby": ["Gemfile", "Rakefile", "*.rake", "*.gemspec"],
+    "HAML": ["*.haml", "*.hamlit"]
+  }
+}

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,9 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+  gem 'ruby-lsp', require: false
+  gem 'ruby-lsp-rails', require: false
+  gem 'ruby-lsp-rspec', require: false
   # gem 'ruby-debug-ide'
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rdoc (6.17.0)
       erb
       psych (>= 4.0.0)
@@ -379,6 +383,14 @@ GEM
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
+    ruby-lsp (0.26.9)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 5)
+    ruby-lsp-rails (0.4.8)
+      ruby-lsp (>= 0.26.0, < 0.27.0)
+    ruby-lsp-rspec (0.1.29)
+      ruby-lsp (~> 0.26.0)
     ruby-progressbar (1.13.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -490,6 +502,9 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  ruby-lsp
+  ruby-lsp-rails
+  ruby-lsp-rspec
   sass-rails (>= 6)
   searchkick (~> 6.1.2)
   sidekiq


### PR DESCRIPTION
## Summary

Zed エディタで ruby-lsp を利用できるようにし、関数定義へのジャンプ・補完・保存時整形などを有効化します。

## 変更内容

- **Gemfile** (development group): `ruby-lsp` / `ruby-lsp-rails` / `ruby-lsp-rspec` を追加（いずれも `require: false`）
  - Rails メタプログラミング（`has_many` 等の generated method）や RSpec の CodeLens に対応させるためアドオンも同梱
- **.zed/settings.json**: 新規追加
  - `ruby-lsp` を有効化、`solargraph` / `rubocop` を明示的に無効化
  - フォーマッタと linter は `rubocop_internal`（ruby-lsp 内蔵の rubocop 呼び出し）に統一
  - `format_on_save: on`
  - inlay hints（implicit rescue / implicit hash value）を有効化
- **.gitignore**: `/.ruby-lsp/`（インデックスキャッシュ）を追加

## 利用手順

1. `bundle install`
2. Zed の Extensions から **Ruby**（公式） / **HAML** をインストール
3. リポジトリを Zed で開くと `.zed/settings.json` が自動読み込みされます

## Test plan

- [ ] `bundle install` が成功する
- [ ] Zed で `.rb` ファイルを開き、`F12` で定義へジャンプできる
- [ ] `cmd+shift+O` でシンボル検索ができる
- [ ] 保存時に rubocop 相当の整形が走る
- [ ] `has_many` などで生成されるメソッドの補完が効く（ruby-lsp-rails）
- [ ] `.gitignore` により `.ruby-lsp/` が追跡されない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ruby向けの開発環境設定を追加し、Zedでの補完・診断・整形・シンボル表示などの機能がより使いやすくなりました。
  * RubyおよびHAMLファイルの認識が改善されました。
* **Chores**
  * 開発時に不要な関連ファイルをGit管理対象外にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->