### PR TITLE
routes.rb の resources :events 二重定義を解消

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :events
   root 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
   delete '/logout' => 'sessions#destroy'


### PR DESCRIPTION
## 概要

config/routes.rb で `resources :events` が2箇所に定義されていたのを1つに統合します。

## 背景

- ルーティングは先勝ちのため、後方(tickets ネスト用)の events ルート6本はすべて先頭の `resources :events` に食われて死んでいました
- 先頭の定義は `GET /events → events#index` を生成しますが、EventsController に index アクションは存在せず(一覧は welcome#index が担当)、到達すると ActionNotFound になる壊れたルートでした
- events に collection ルートを追加する際、後方のブロックに書くと先頭定義の `GET /events/:id` に先にマッチして動かない、という追記の罠にもなっていました

## 変更内容

先頭の `resources :events`(全アクション)を削除し、tickets をネストする既存の定義に一本化しました。

## 影響

`bin/rails routes` の修正前後 diff で確認済み:

- 消えるルートはアクション未実装の `GET /events`(events#index)の1本のみ
- その他のパス・アクションはすべて同一。名前付きヘルパー(events_path / new_event_path / edit_event_path / event_path)は存続する定義側に付き直るだけで、生成されるヘルパー・パスに変化なし
- `events_path` は create(POST /events)が同じパスを持つため引き続き利用可能(使用箇所は spec の `post events_path` 2箇所のみ)

## 検証

- `bin/rails routes` の前後 diff(上記)
- `bundle exec rubocop config/routes.rb` パス
- RSpec はローカル Docker が起動不能だったため CI にて確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
