### PR TITLE
CLAUDE.md をディレクトリ分割し検証で効果のある項目だけに絞る

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,87 +4,29 @@
 
 ## プロジェクト概要
 
-Rails 8 で構築されたイベント管理Webアプリケーションです。ユーザーはイベントの作成・編集・管理が可能で、他のユーザーはイベントの閲覧やチケット登録（参加登録）ができます。GitHub OAuth による認証を採用しています。
+Rails 8 のイベント管理アプリ。ユーザーはイベントを作成・編集し、他のユーザーはチケット登録（参加登録）する。認証は GitHub OAuth のみ。テンプレートは Hamlit（.haml）。
 
-## 技術スタック
+## バージョンの正
 
-- **Ruby**: 4.0.1（.tool-versions で管理）
-- **Rails**: 8.1.0
-- **Node.js**: 24.13.0
-- **パッケージマネージャ**: pnpm 10.28.2
-- **データベース**: MySQL 8.0/9.6（mysql2 アダプタ）
-- **検索エンジン**: Elasticsearch 7.17.9 + Searchkick
-- **バックグラウンドジョブ**: Sidekiq
-- **テンプレートエンジン**: Hamlit
-- **フロントエンド**: Stimulus、Turbo、Bootstrap 5、jQuery、Vue.js 3
-- **アセットバンドル**: Webpack 5 + jsbundling-rails
+Ruby / Node.js は .tool-versions、pnpm は package.json の packageManager が正。このファイルにバージョン数値は書かない（更新漏れで嘘になるため）。
 
-## よく使うコマンド
+## 検索エンジン
 
-### 開発環境
+searchkick を使うが、接続先は Elasticsearch ではなく OpenSearch（config/initializers/searchkick.rb で OpenSearch::Client に差し替え済み）。環境変数名は歴史的経緯で ELASTIC_SEARCH_URL のまま。CI だけは Elasticsearch 7.17.9 で動くため、どちらか一方にしかない API は使わない。
 
-```bash
-bundle install                    # Rubyの依存関係をインストール
-pnpm install                      # JavaScriptの依存関係をインストール
-bundle exec rails db:create       # データベースを作成
-bundle exec rails db:migrate      # マイグレーションを実行
-bundle exec rails assets:precompile  # アセットをビルド
-bundle exec rails server          # 開発サーバーを起動
-```
+## 開発・テスト実行の前提
 
-### テスト
+- DB（MySQL）と OpenSearch は docker-compose で動かし、接続情報は .envrc（direnv）が供給する（MYSQL_HOST=rails-db.lvh.me / MYSQL_PORT=53306）。コンテナ未起動や direnv 未ロードの状態で bundle exec rspec を実行すると接続エラーで全滅する
+- Searchkick のテスト用スタブは無く、検索を検証する spec は実エンジンに接続する
+- JS パッケージ操作は pnpm のみ（pnpm-lock.yaml が正）
+- アセットビルドは bundle exec rails assets:precompile（内部で pnpm build を呼ぶ）。webpack 設定はルートではなく config/webpack/webpack.config.js にある
 
-```bash
-bundle exec rspec                 # 全テストを実行
-bundle exec rspec spec/models/    # モデルのテストのみ実行
-bundle exec rspec spec/requests/  # リクエストのテストのみ実行
-bundle exec rspec spec/some_spec.rb  # 特定のテストファイルを実行
-```
+## 品質チェック
 
-### コード品質
+- CI（PR 時）は Brakeman → RSpec → Codecov のみで、RuboCop は走らない。コミット前に手動で bundle exec rubocop を実行する
+- 日本語コメント可（Style/AsciiComments 無効）
 
-```bash
-bundle exec rubocop               # RuboCopによる静的解析を実行
-bundle exec rubocop -a             # 自動修正可能な違反を修正
-bundle exec brakeman               # セキュリティ脆弱性のスキャンを実行
-```
+## ブランチ・PR
 
-## アーキテクチャ
-
-### ディレクトリ構成
-
-- `app/controllers/` - Railsコントローラ（sessions, events, tickets, welcome など）
-- `app/models/` - ActiveRecordモデル（User, Event, Ticket）
-- `app/views/` - Hamlitテンプレート（.haml ファイル）
-- `app/forms/` - フォームオブジェクト
-- `app/jobs/` - Sidekiqバックグラウンドジョブ
-- `app/javascript/` - ESモジュール（Stimulus コントローラなど）
-- `app/assets/` - SCSS スタイルシートと画像
-- `spec/` - RSpecテスト
-- `spec/factories/` - FactoryBotのファクトリ定義
-
-### 主要モデル
-
-- **User** - GitHub OAuth で認証されるユーザー
-- **Event** - イベント情報（画像アップロード対応、Active Storage使用）
-- **Ticket** - イベントへの参加登録
-
-### 認証
-
-OmniAuth + omniauth-github による GitHub OAuth 認証を使用しています。
-
-## テスト
-
-- **フレームワーク**: RSpec
-- **テストデータ**: FactoryBot
-- **カバレッジ**: SimpleCov（coverage/ ディレクトリに出力）
-- **CI**: GitHub Actions（PR作成時に自動実行）
-- **CI構成**: RSpec実行 → Brakeman → Codecov
-
-## コーディング規約
-
-- RuboCop（rubocop-rails, rubocop-performance プラグイン使用）に準拠
-- `.rubocop.yml` と `.rubocop_todo.yml` で設定を管理
-- 日本語コメントが許可されています（`Style/AsciiComments: Enabled: false`）
-- テンプレートは Hamlit（.haml）を使用
-- i18n による日本語対応（rails-i18n gem）
+- PR は main ベース
+- ブランチ名は feature/ fix/ chore/ refactor/ doc/ のプレフィックスを付ける（release-drafter がラベルを自動付与するため）

--- a/app/controllers/CLAUDE.md
+++ b/app/controllers/CLAUDE.md
@@ -1,0 +1,3 @@
+# app/controllers の注意点
+
+- TicketsController#new が RoutingError を raise しているのは意図的。チケットはイベント show 画面から直接 POST で作る設計で、new 画面は存在しない。フォーム描画に「修正」しない

--- a/app/javascript/CLAUDE.md
+++ b/app/javascript/CLAUDE.md
@@ -1,0 +1,3 @@
+# app/javascript の注意点
+
+- Turbolinks と Turbo の同居は意図的。get_form_turbolinks.js は GET の remote フォームを Turbolinks.visit に変換する回避策で、config.action_view.form_with_generates_remote_forms = true とセットで動く。どちらか一方だけ消すと検索フォームが壊れる

--- a/app/models/CLAUDE.md
+++ b/app/models/CLAUDE.md
@@ -1,0 +1,3 @@
+# app/models の注意点
+
+- Ticket の belongs_to :user, optional: true はバグではない。退会（User#destroy）時に dependent: :nullify で tickets.user_id / events.owner_id を NULL 化し、ビューが「退会したユーザです」と表示する設計。required に「修正」すると退会が壊れる


### PR DESCRIPTION
## 概要

CLAUDE.md をディレクトリ分割し、「書いてないと AI がコードを書き間違える・レビューで誤指摘する事項」だけに絞ります。

## 変更内容

- ルート CLAUDE.md を約90行から約35行に縮小。全セッションで効く事項のみ残しました
  - 環境前提(direnv + docker-compose、コンテナ未起動だと rspec 全滅)
  - 検索エンジンの二重構成(接続先は OpenSearch、CI のみ Elasticsearch 7.17.9)
  - CI で RuboCop が走らない(lint は手動)
  - PR は main ベース + ブランチ名プレフィックス規約
  - バージョン数値の記載を廃止し .tool-versions / package.json への参照に変更(記載値が実体とズレて嘘になっていたため)
- 「バグに見える意図的設計」を該当ディレクトリに各1項目配置(そのコードを触るときだけ読まれる)
  - app/controllers: TicketsController#new の意図的 raise
  - app/models: Ticket の optional: true と退会時 nullify の設計
  - app/javascript: Turbolinks + Turbo 同居の理由

## 選定方法

main から作った2つの worktree(新 CLAUDE.md あり/なし)で、Opus のサブエージェントに同一タスク3種(コントローラ機能追加・request spec 追加・JS 機能追加)を実行させて成果物を比較しました。

- 認証 opt-out、created_events による認可、sign_in_as、Event.reindex、素の JS 方式などの規約は、CLAUDE.md なしでも既存コードの模倣で全て守られたため記載しない
- routes.rb の二重定義だけは「なし」条件のエージェントが実際に踏んで動かないルートを作ったため、記述ではなく #1848 でコード側を解消済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 開発・テスト・ブランチ運用に関する案内を整理し、プロジェクトの前提条件や作業手順をわかりやすくしました。
  * 各画面・機能の注意事項を追記し、検索フォームやチケット作成、退会後の表示などの挙動について誤解しにくくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->