### PR TITLE
CI の apt-get install を非対話化しステップ名のタイポを修正

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -71,8 +71,8 @@ jobs:
             --ulimit memlock=-1:-1 \
             rails8-opensearch
       #MySQLをインストール
-      - name: Install dependent libralies
-        run: sudo apt-get update -y && sudo apt-get install libmysqlclient-dev
+      - name: Install dependent libraries
+        run: sudo apt-get update -y && sudo apt-get install -y libmysqlclient-dev
       - name: Verify OpenSearch connection from host
         run: |
           echo "${OPENSEARCH_URL}"

--- a/.steering/20260719-load-defaults-8-0/design.md
+++ b/.steering/20260719-load-defaults-8-0/design.md
@@ -1,0 +1,82 @@
+# 設計書
+
+## アーキテクチャ概要
+
+コード変更は設定ファイル 5 ファイルのみ。アプリケーションコードには触れない。
+
+```
+config/application.rb                              load_defaults 7.1 → 8.0
+config/initializers/new_framework_defaults_8_0.rb  削除
+config/environments/production.rb                  cache_classes → enable_reloading
+config/environments/development.rb                 cache_classes → enable_reloading
+config/environments/test.rb                        cache_classes → enable_reloading
+```
+
+## 変更内容の根拠（railties-8.1.3 実測）
+
+### load_defaults 7.1 → 8.0 で新たに適用されるデフォルト
+
+| 設定 | 影響 |
+|------|------|
+| `self.yjit = true`（7.2） | YJIT 有効化。パフォーマンス改善のみ |
+| `active_storage.web_image_content_types` に webp 追加（7.2） | variant 生成時の扱いのみ。既存画像に影響なし |
+| `active_record.validate_migration_timestamps = true`（7.2） | 新規マイグレーション作成時のみ |
+| `active_record.postgresql_adapter_decode_dates = true`（7.2） | MySQL のため no-op |
+| `action_dispatch.strict_freshness = true`（8.0） | initializer で有効化済み → 挙動変化なし |
+| `Regexp.timeout \|\|= 1`（8.0） | initializer で有効化済み → 挙動変化なし |
+
+### new_framework_defaults_8_0.rb を削除できる理由
+
+- `strict_freshness` / `Regexp.timeout` → load_defaults 8.0 がカバー
+- `to_time_preserves_timezone = :zone` → activesupport-8.1.3 で setter 自体が deprecated（"will be removed in Rails 8.2"）。設定を残すと起動毎に deprecation 警告が出る。8.1 では :zone 相当が固定挙動のため削除で挙動変化なし
+
+### cache_classes → enable_reloading
+
+railties-8.1.3 では `enable_reloading = !cache_classes` の関係（configuration.rb:380-384）。値を反転して置換する:
+
+- production.rb: `cache_classes = true` → `enable_reloading = false`
+- development.rb: `cache_classes = false` → `enable_reloading = true`
+- test.rb: `cache_classes = true` → `enable_reloading = false`
+
+### 保持するもの（罠になりやすい点）
+
+- `application.rb:39` `config.action_view.form_with_generates_remote_forms = true` — actionview-8.1.3 に現存する有効な API。UJS の js.erb フローがこれに依存しているため、削除すると #1858 の 500 が顕在化する。**触らない**
+
+## エラーハンドリング戦略
+
+設定変更のみのためカスタムエラー処理は不要。リスクは「起動不能」「テスト失敗」の 2 点で、検証フェーズで検出する。
+
+## テスト戦略
+
+### 起動スモークテスト
+- `bin/rails runner` での起動確認と、stderr の deprecation 警告チェック
+
+### 回帰テスト
+- `bundle exec rspec` 全件（要 docker compose の MySQL/OpenSearch + direnv）
+- `bundle exec rubocop`（CI では走らないため手動必須 — CLAUDE.md）
+
+## 依存ライブラリ
+
+追加なし。
+
+## 実装の順序
+
+1. main から `refactor/1865-load-defaults-8-0` ブランチ作成
+2. application.rb の load_defaults 変更
+3. new_framework_defaults_8_0.rb 削除
+4. environments 3 ファイルの cache_classes 置換
+5. 起動確認 → rspec → rubocop
+6. コミット
+
+## セキュリティ考慮事項
+
+- Regexp.timeout / strict_freshness は既に有効のため、セキュリティ姿勢の後退はない
+- force_ssl には触れない（#1860）
+
+## パフォーマンス考慮事項
+
+- YJIT が production で有効化される（7.2 デフォルト）。メモリ使用量が微増する可能性があるが、Rails 公認のデフォルト
+
+## 将来の拡張性
+
+- 8.0 到達後、次のステップとして `load_defaults 8.1`（escape_json_responses / render_tracker / remove_hidden_field_autocomplete 等の検証が必要）を別 Issue で実施可能

--- a/.steering/20260719-load-defaults-8-0/requirements.md
+++ b/.steering/20260719-load-defaults-8-0/requirements.md
@@ -1,0 +1,57 @@
+# 要求内容
+
+## 概要
+
+Rails 8.1.3 で稼働中のアプリの `config.load_defaults` を 7.1 から 8.0 へ引き上げ、旧世代の環境設定 API（`cache_classes`）を現行 API に置き換える（Issue [#1865](https://github.com/kaki-org/rails8/issues/1865)）。
+
+## 背景
+
+- `config/application.rb:27` が `config.load_defaults 7.1` のままで、Rails 8.1.3 に対し 2 世代前のデフォルトで動作している
+- `config/initializers/new_framework_defaults_8_0.rb` は全 3 項目が有効化済みで、移行完了状態なのにファイルが残っている
+- `config/environments/*.rb` が非推奨の旧スタイル `config.cache_classes` を使用している（現行は `config.enable_reloading`）
+
+## 実装対象の機能
+
+### 1. load_defaults の 8.0 への引き上げ
+- `config/application.rb` の `config.load_defaults 7.1` → `8.0`
+- 7.2 差分（YJIT 有効化、Active Storage webp 対応、migration timestamp 検証、PostgreSQL 専用設定 = MySQL では no-op）と 8.0 差分（strict_freshness、Regexp.timeout = initializer で有効化済み）を一括適用
+
+### 2. new_framework_defaults_8_0.rb の削除
+- `strict_freshness` / `Regexp.timeout` は load_defaults 8.0 がカバー
+- `to_time_preserves_timezone` は Rails 8.1 で deprecated（8.2 で削除予定）のため、設定ごと削除して deprecation 警告を解消
+
+### 3. 環境設定ファイルの近代化
+- `cache_classes` → `enable_reloading` への置換（production / development / test）
+- 挙動は変えない（値の反転のみ: `cache_classes = true` ⇔ `enable_reloading = false`）
+
+## 受け入れ条件
+
+### load_defaults 8.0
+- [ ] `bin/rails runner` でアプリが正常起動する
+- [ ] 起動時に deprecation 警告が出ない（特に to_time_preserves_timezone）
+- [ ] `bundle exec rspec` が全件パスする
+
+### 環境設定近代化
+- [ ] `cache_classes` の参照が config/ から消えている
+- [ ] `bundle exec rubocop` がエラーなし
+
+## 成功指標
+
+- Rails 8.2 へのアップグレード障壁（deprecated 設定）が 1 つ解消される
+- new_framework_defaults の管理ファイルが不要になる
+
+## スコープ外
+
+以下はこのフェーズでは実装しません:
+
+- `config.force_ssl` の有効化 — Issue #1860 のスコープ
+- Active Storage の :local からの移行 — Issue #1866 のスコープ
+- `load_defaults 8.1` への引き上げ — 8.1 差分（escape_json_responses、render_tracker 等）は挙動影響の検証が別途必要なため段階を分ける
+- `config/environments/*.rb` の Rails 8 テンプレートでの全面再生成 — force_ssl / storage 等の挙動変更を伴い #1860 / #1866 と衝突するため、今回は deprecated API の置換に留める
+- `application.rb:39` の `form_with_generates_remote_forms = true` の削除 — UJS 依存の js.erb フローが現存するため保持（Issue #1858 / #1864 のスコープ）
+
+## 参照ドキュメント
+
+- Issue: https://github.com/kaki-org/rails8/issues/1865
+- CLAUDE.md（プロジェクトの開発・テスト前提）
+- railties-8.1.3 `lib/rails/application/configuration.rb`（load_defaults 差分の一次情報）

--- a/.steering/20260719-load-defaults-8-0/tasklist.md
+++ b/.steering/20260719-load-defaults-8-0/tasklist.md
@@ -1,0 +1,75 @@
+# タスクリスト
+
+## 🚨 タスク完全完了の原則
+
+**このファイルの全タスクが完了するまで作業を継続すること**
+
+### 必須ルール
+- **全てのタスクを`[x]`にすること**
+- 「時間の都合により別タスクとして実施予定」は禁止
+- 未完了タスク（`[ ]`）を残したまま作業を終了しない
+- スキップは技術的理由がある場合のみ（`- [x] ~~タスク名~~（理由）` 形式で明記）
+
+---
+
+## フェーズ1: 準備
+
+- [x] main から作業ブランチ `refactor/1865-load-defaults-8-0` を作成
+- [x] bundle install で依存が揃っていることを確認
+- [x] docker compose の MySQL / OpenSearch 起動と direnv 環境変数を確認（rspec 実行前提）
+
+## フェーズ2: 実装
+
+- [x] `config/application.rb` の `config.load_defaults 7.1` を `8.0` に変更
+- [x] `config/initializers/new_framework_defaults_8_0.rb` を削除
+- [x] `config/environments/production.rb` の `cache_classes = true` を `enable_reloading = false` に置換
+- [x] `config/environments/development.rb` の `cache_classes = false` を `enable_reloading = true` に置換
+- [x] `config/environments/test.rb` の `cache_classes = true` を `enable_reloading = false` に置換
+
+## フェーズ3: 品質チェックと修正
+
+- [x] アプリが正常起動し deprecation 警告が出ないことを確認
+  - [x] `bin/rails runner`（development 環境）で起動確認
+  - [x] test 環境でも起動確認
+- [x] すべてのテストが通ることを確認
+  - [x] `bundle exec rspec`（44 examples, 0 failures, 1 pending=既存の未実装 view spec）
+- [x] リントエラーがないことを確認
+  - [x] `bundle exec rubocop`（今回の変更起因の違反ゼロ。Gemfile の Style/StringLiterals 4件は main 由来の既存違反でスコープ外）
+
+## フェーズ4: 仕上げ
+
+- [x] コミット作成（コミット規約: 日本語1行 + 箇条書き、Co-Authored-By なし）→ a138017
+- [x] 実装後の振り返り（このファイルの下部に記録）
+
+---
+
+## 実装後の振り返り
+
+### 実装完了日
+2026-07-19
+
+### 計画と実績の差分
+
+**計画と異なった点**:
+- コード変更自体は計画どおり（config 5ファイル、+4/-36行）。差分はすべて検証環境の整備で発生した
+
+**新たに必要になったタスク**:
+- mysql2 gem の再ビルド: 以前のビルドが削除済みの brew mysql@8.0 の dylib にリンクしていたため、mysql-client@8.0 を導入し `.bundle/config` の build.mysql2 を更新
+- colima の VM メモリ増設（2GiB→6GiB, 2CPU→4CPU）: Supabase スタック等と OpenSearch が同居できず OOM（exit 137）を繰り返したため、ユーザー了承のうえ実施
+- OpenSearch ボリュームの再作成: `rails8_elasticsearch` ボリュームに旧 Elasticsearch 9 イメージ（stale build）のデータが残っており OpenSearch 2.18 が起動不能（`data/nodes/0: Not a directory`）だったため、`docker compose up -d --build elasticsearch` で現行 Dockerfile から再ビルドし、派生データであるインデックスボリュームを削除・再作成
+
+### 学んだこと
+
+**技術的な学び**:
+- 7.1→8.0 の実効差分は railties の `load_defaults` の case 文で機械的に確認できる。8.0 の新デフォルト2項目は initializer で有効化済みだったため一気に引き上げ可能だった
+- `to_time_preserves_timezone` は 8.1 で setter 自体が deprecated（8.2 削除予定）で、`to_time` の挙動は設定値を参照しない固定実装。設定を残すと起動毎に警告が出るだけ
+- `enable_reloading` は `!cache_classes` の単純ラッパー（railties configuration.rb）なので置換は挙動不変
+- `application.rb` の `form_with_generates_remote_forms = true` は UJS の js.erb フローの生命線（#1858/#1864 の同根）。defaults 引き上げ時に消してはいけない
+
+**プロセス上の改善点**:
+- 検証前に「ローカル環境が実際に動くか」（gem のネイティブ拡張、docker VM のメモリ、ボリュームの中身）を先に確認すべきだった。実装 10 分に対し環境復旧に大半の時間を費やした
+
+### 次回への改善提案
+- `load_defaults 8.1` への引き上げは別 Issue で（escape_json_responses / render_tracker / remove_hidden_field_autocomplete / dev・test での YJIT 無効化の検証が必要）
+- ES コンテナのイメージが stale だと Dockerfile と乖離する。`docker compose up --build` を検証手順に含めると再発防止になる
+- Gemfile に main 由来の RuboCop 違反（Style/StringLiterals ×4）が残っている。別途軽微 PR で解消可能

--- a/.steering/20260720-opensearch-migration-cleanup/design.md
+++ b/.steering/20260720-opensearch-migration-cleanup/design.md
@@ -1,0 +1,60 @@
+# 設計: OpenSearch 移行の残作業
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 | 対応要件 |
+|---|---|---|
+| `GEMINI.md` | 検索エンジン表記を OpenSearch 2.18.0 + Searchkick に | R1 |
+| `devenv/elasticsearch/` → `devenv/opensearch/` | `git mv` でディレクトリリネーム | R2 |
+| `docker-compose.yml` | サービス名 / ボリューム名 / `depends_on` / Dockerfile パス / env を opensearch に | R2, R4 |
+| `dip.yml` | `provision` の `dip compose up -d db redis elasticsearch` を opensearch に | R2 |
+| `.github/workflows/ruby.yml` | ES action を廃止し、devenv の Dockerfile をビルドして OpenSearch を起動 | R3, R4 |
+| `config/initializers/searchkick.rb` | `OPENSEARCH_URL` 優先・`ELASTIC_SEARCH_URL` フォールバック | R4 |
+| `CLAUDE.md` | CI も OpenSearch になった旨に更新 | R5 |
+
+## 設計判断
+
+### D1: CI の OpenSearch 起動方法
+
+`searchkick language: 'japanese'` が **analysis-kuromoji** プラグインを要求するため、
+プラグイン無しの素の公式イメージは使えない。
+
+検討した選択肢:
+
+| 案 | 内容 | 判定 |
+|---|---|---|
+| A | `devenv/opensearch/Dockerfile` を CI でビルドして `docker run` | **採用** |
+| B | `services:` に素の `opensearchproject/opensearch` を指定 | 却下: kuromoji が無く spec が落ちる |
+| C | `services:` 起動後にプラグインを後入れ | 却下: プラグイン反映に再起動が必要 |
+
+案 A はローカル開発環境と CI で **同一の Dockerfile** を使うため、
+「実装と説明の乖離」という Issue の根本原因を再発させない点でも優れる。
+
+`services:` ブロックを使わないのは、既存コメント（L42「起動数が多すぎるせいか rspec が
+動かなくなる」）の経緯を踏襲し、明示的な `docker run` + ヘルスチェック待ちにするため。
+
+### D2: 環境変数のフォールバック
+
+```ruby
+Searchkick.client = OpenSearch::Client.new(
+  url: ENV.fetch('OPENSEARCH_URL', nil) || ENV.fetch('ELASTIC_SEARCH_URL', nil)
+)
+```
+
+`OPENSEARCH_URL` を正とし、旧名は移行期間の互換用に残す。
+どちらも未設定なら `nil` が渡り、opensearch-ruby のデフォルト
+（`http://localhost:9200`）が使われる — 現行挙動と同じ。
+
+### D3: ボリューム名のリネーム
+
+`elasticsearch` ボリュームを `opensearch` にリネームすると既存ローカルボリュームは
+参照されなくなる（インデックスは消える）。検索インデックスは `rails searchkick:reindex`
+または seed で再生成可能なため許容する。tasklist に開発者向け申し送りを残す。
+
+## 検証方針
+
+1. `docker compose config` で compose 定義の妥当性を確認
+2. `devenv/opensearch/Dockerfile` をローカルでビルドし、起動して
+   `_cat/plugins` に analysis-kuromoji / analysis-icu が出ることを確認
+3. `bundle exec rubocop` / `bundle exec rspec`（検索 spec を含む）を実行
+4. `actionlint`（あれば）で workflow 構文を確認

--- a/.steering/20260720-opensearch-migration-cleanup/requirements.md
+++ b/.steering/20260720-opensearch-migration-cleanup/requirements.md
@@ -1,0 +1,41 @@
+# 要件: OpenSearch 移行の残作業
+
+対象 Issue: https://github.com/kaki-org/rails8/issues/1842
+
+## 背景
+
+実装（Gemfile / config/initializers/searchkick.rb）は OpenSearch に移行済みだが、
+ドキュメント・CI・コンテナ定義の一部が Elasticsearch を参照したままで乖離している。
+
+## Issue 記載内容の現況確認（2026-07-20 時点）
+
+| Issue の指摘 | 現況 | 対応 |
+|---|---|---|
+| `CLAUDE.md:16` が Elasticsearch 表記 | **修正済み**（OpenSearch と明記） | CI 移行に伴う追記のみ |
+| `GEMINI.md:8,14` が Elasticsearch 表記 | 未対応 | 要修正 |
+| `devenv/elasticsearch/Dockerfile` が ES イメージ | **修正済み**（`opensearchproject/opensearch:2.18.0`） | ディレクトリ名のみ要リネーム |
+| CI が Elasticsearch 7.17.9 を起動 | 未対応 | 要修正 |
+| env 名 `ELASTIC_SEARCH_URL` | 未対応 | 要修正（互換維持） |
+
+## 要件
+
+1. **R1**: `GEMINI.md` の検索エンジン表記を OpenSearch 実態に合わせる
+2. **R2**: `devenv/elasticsearch/` を `devenv/opensearch/` にリネームし、`docker-compose.yml` /
+   `dip.yml` のサービス名・ボリューム名も `opensearch` に統一する
+3. **R3**: CI（`.github/workflows/ruby.yml`）の検索バックエンドを OpenSearch に差し替える。
+   `searchkick language: 'japanese'` が analysis-kuromoji を必要とするため、
+   プラグイン入りイメージを使うこと
+4. **R4**: 環境変数を `OPENSEARCH_URL` にリネームし、移行期間中は `ELASTIC_SEARCH_URL` も
+   フォールバックとして受け付ける
+5. **R5**: `CLAUDE.md` の「CI だけは Elasticsearch 7.17.9 で動く」という記述を実態に合わせる
+
+## 非機能要件 / 制約
+
+- CI の `timeout-minutes: 7` を超えないこと（OpenSearch イメージのビルド時間に注意）
+- ローカル開発環境（docker compose）が引き続き動作すること
+- 既存の spec を壊さないこと
+
+## スコープ外
+
+- searchkick の設定変更・検索仕様の変更
+- OpenSearch のバージョンアップ

--- a/.steering/20260720-opensearch-migration-cleanup/tasklist.md
+++ b/.steering/20260720-opensearch-migration-cleanup/tasklist.md
@@ -1,0 +1,72 @@
+# タスクリスト: OpenSearch 移行の残作業
+
+- [x] T1: `GEMINI.md` の Elasticsearch 表記を OpenSearch に修正（R1）
+- [x] T2: `devenv/elasticsearch/` を `devenv/opensearch/` に `git mv` でリネーム（R2）
+- [x] T3: `docker-compose.yml` のサービス名・ボリューム名・Dockerfile パス・env を opensearch に統一（R2, R4）
+- [x] T4: `dip.yml` の provision コマンドのサービス名を修正（R2）
+- [x] T5: `config/initializers/searchkick.rb` を `OPENSEARCH_URL` 優先 + 旧名フォールバックに（R4）
+- [x] T6: `.github/workflows/ruby.yml` の検索バックエンドを OpenSearch に差し替え（R3, R4）
+- [x] T7: `CLAUDE.md` の検索エンジン記述を実態に合わせて更新（R5）
+- [x] T8: OpenSearch イメージをローカルでビルド・起動し、kuromoji/icu プラグインの導入を確認（検証）
+- [x] T9: `bundle exec rubocop` を実行しパスさせる（検証）
+- [x] T10: `bundle exec rspec` を実行しパスさせる（検証）
+- [x] T11: env 変数の優先順位・フォールバック・デフォルトを実機で検証（T8 実施中に必要と判明し追加）
+- [x] T12: implementation-validator の指摘対応（検証後に追加）
+  - `Verify OpenSearch plugins` が一覧表示のみでアサートしていなかったため `grep -q` を追加
+  - OpenSearch イメージの pull/build がクリティカルパスに乗るため `timeout-minutes` を 7 → 10 に緩和
+
+## 検証ログ（2026-07-20）
+
+| 検証 | 結果 |
+|---|---|
+| `docker compose config` | OK |
+| `actionlint .github/workflows/ruby.yml` | OK |
+| `devenv/opensearch/Dockerfile` ビルド + 起動 | health `green` / version `2.18.0` |
+| `_cat/plugins` | `analysis-icu`, `analysis-kuromoji` を確認 |
+| `docker compose up -d opensearch` | health `green` / プラグイン導入済み |
+| `OPENSEARCH_URL` 指定時 | `127.0.0.1:19200` に接続、`ping=true` |
+| `OPENSEARCH_URL` 空 + `ELASTIC_SEARCH_URL` 指定 | フォールバック成功、`ping=true` |
+| 両方未設定 | `localhost:9200`（従来どおりのデフォルト） |
+| `bundle exec rubocop config/initializers/searchkick.rb` | no offenses |
+| `bundle exec rspec` | 44 examples, 0 failures, 1 pending |
+
+## 申し送り事項
+
+**実装完了日**: 2026-07-20
+
+### 計画と実績の差分
+
+- Issue の記述が一部古く、`devenv/elasticsearch/Dockerfile` は既に
+  `opensearchproject/opensearch:2.18.0` に、`CLAUDE.md` も既に OpenSearch 表記に
+  修正済みだった。実作業はディレクトリ名・CI・env 名・`GEMINI.md` に絞られた。
+- 計画外に T11 を追加。`ENV.fetch(...) || ENV.fetch(...)` だと **空文字**の
+  `OPENSEARCH_URL` がフォールバックを潰し、`hosts=[]` の接続先ゼロのクライアントが
+  出来ることを実機検証で発見したため、`.presence` を挟んだ。
+
+### 学んだこと
+
+- 「env 変数を渡すだけ」の変更でも、空文字と未設定の差でクライアントの挙動が変わる。
+  Ruby では空文字が truthy なので `||` フォールバックは `.presence` とセットで書く。
+- OpenSearch 公式イメージは analysis-kuromoji / analysis-icu を**同梱していない**。
+  `searchkick language: 'japanese'` があるため、CI で素の公式イメージに差し替えると
+  spec が落ちる。ローカルと同じ Dockerfile をビルドして使う方針にした。
+
+### 開発者向け移行手順（要周知）
+
+compose のサービス名・ボリューム名が `elasticsearch` → `opensearch` に変わったため、
+既存環境では旧コンテナが orphan として残り 9200 番ポートを掴んだままになる。
+一度だけ以下を実行すること:
+
+```
+docker compose down --remove-orphans
+docker compose up -d db redis opensearch
+```
+
+ボリュームも別名になるため検索インデックスは失われる。`bin/rails searchkick:reindex`
+または `rails db:seed` で再生成する。
+
+### 次回への改善提案
+
+- `ELASTIC_SEARCH_URL` フォールバックは移行期間限定。周知後に別 PR で削除する。
+- 検索機能を実際に叩く spec が無く（`spec/requests/welcome_spec.rb` のみが関連）、
+  CI で OpenSearch が壊れても検知できない。検索の request spec 追加を検討する。


### PR DESCRIPTION
## 概要

CI の依存ライブラリインストールステップを非対話化し、ステップ名のタイポを修正します。

```diff
-      - name: Install dependent libralies
-        run: sudo apt-get update -y && sudo apt-get install libmysqlclient-dev
+      - name: Install dependent libraries
+        run: sudo apt-get update -y && sudo apt-get install -y libmysqlclient-dev
```

## 背景

#1869（OpenSearch 移行の残作業）のレビューで CodeRabbit が指摘した内容です。指摘は妥当ですが **#1869 が変更していない既存行**に対するものだったため、1PR = 1つの関心事の原則に従い本 PR に分離しました。

## これはバグ修正ではなく予防的な堅牢化です

現状 CI は通っており、この行が原因で失敗した実績はありません。`apt-get install` が確認プロンプトを出すのは**追加パッケージのインストールを伴う場合のみ**で、現在は `libmysqlclient-dev` の依存が runner イメージに揃っているため素通りしていると考えられます。

ただし GitHub Actions runner イメージの更新で依存関係が変われば、非対話環境では確認待ちのまま `Abort.` で失敗します。`-y` はその予防です。

なお、実際の CI ログでプロンプトの有無を確認しようとしましたが、GitHub API が HTTP 503 を返し続けたため取得できませんでした。上記は apt-get の仕様に基づく推論です。

## ⚠️ #1869 とコンフリクトします

ローカルでマージを試して確認済みです。本 PR が変更する行の直後を #1869 が変更している（`Verify Elasticsearch connection from host` → `Verify OpenSearch connection from host`）ためで、解決は自明です。

**推奨マージ順**: 本 PR（1行、低リスク）を先にマージ → #1869 を rebase。逆順でも構いません。

## 検証

- `actionlint .github/workflows/ruby.yml` → OK
- CI の全チェック（本 PR で実行されるもの）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - Rails の設定を 8.0 へ移行するための要件、設計、作業手順を追加しました。
  - OpenSearch 移行に関する残作業、検証方法、運用手順を整理しました。

- **改善**
  - CI で MySQL 開発ライブラリを自動インストールできるようにし、手順名の誤字を修正しました。
  - OpenSearch 移行時の環境変数や検索設定、プラグイン確認方法を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->