### PR TITLE
ドキュメントのバージョン情報を出典と一致させる

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,12 +8,15 @@
 - **主要機能**: イベント作成・編集・削除、画像アップロード (Active Storage)、イベント検索 (Searchkick/OpenSearch)、参加登録 (Tickets)。
 
 ## 2. 技術スタック & 開発環境
-- **Runtime**: Ruby 4.0.1, Node.js 24.14.0, pnpm 10.28.2
+
+バージョンの正は各出典ファイル（Ruby / Node.js は `.tool-versions`、Rails は `Gemfile`、pnpm / Bootstrap は `package.json`、MySQL は `docker-compose.yml`、OpenSearch は `devenv/opensearch/Dockerfile`）。以下と食い違う場合は出典側が正。
+
+- **Runtime**: Ruby 4.0.3, Node.js 24.15.0, pnpm 10.33.2
 - **Framework**: Rails 8.1.0
-- **Database**: MySQL 8.0/9.6
+- **Database**: MySQL 9.7
 - **Search**: OpenSearch 2.18.0 + Searchkick (opensearch-ruby)
 - **Background Jobs**: Sidekiq
-- **Frontend**: Bootstrap 5.3.7, Hamlit (Template), Stimulus, Turbo, Webpack 5
+- **Frontend**: Bootstrap 5.3.8, Hamlit (Template), Stimulus, Turbo, Webpack 5
 - **Testing**: RSpec, Capybara (Playwright), SimpleCov
 - **Linting**: RuboCop (rubocop-rails, rubocop-performance)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Rails 8 を使用したイベント管理・参加申込みシステムです。
 ### 前提条件
 
 - Docker & Docker Compose
-- MySQL クライアントライブラリ 8.0 (Docker を使わずローカルで動かす場合のみ。mysql2 gem のビルドに必要。DB サーバ本体は docker-compose の MySQL 9.7 を使う)
+- MySQL クライアントライブラリ 8.0 (アプリをホスト上で実行する場合に必要。mysql2 gem のビルドに使用し、DB サーバは docker-compose の MySQL 9.7 を利用)
 
 ### 初期構築
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Rails 8 を使用したイベント管理・参加申込みシステムです。
 
 ### バックエンド
 
-- **Ruby**: 3.4.5
-- **Rails**: 8.0.0
-- **データベース**: MySQL 8.0
+- **Ruby**: 4.0.3
+- **Rails**: 8.1.0
+- **データベース**: MySQL 9.7
 - **認証**: OmniAuth (GitHub)
 - **検索**: Searchkick + OpenSearch
 - **バックグラウンドジョブ**: Sidekiq
@@ -41,7 +41,7 @@ Rails 8 を使用したイベント管理・参加申込みシステムです。
 ### フロントエンド
 
 - **JavaScript**: Stimulus Rails, Turbo Rails
-- **CSS**: Bootstrap 5.3.7, SCSS
+- **CSS**: Bootstrap 5.3.8, SCSS
 - **バンドラー**: Webpack
 - **その他**: jQuery, Vue.js 3
 
@@ -74,7 +74,7 @@ Rails 8 を使用したイベント管理・参加申込みシステムです。
 ### 前提条件
 
 - Docker & Docker Compose
-- MySQL 8.0 (ローカル開発の場合)
+- MySQL クライアントライブラリ 8.0 (Docker を使わずローカルで動かす場合のみ。mysql2 gem のビルドに必要。DB サーバ本体は docker-compose の MySQL 9.7 を使う)
 
 ### 初期構築
 


### PR DESCRIPTION
## 概要

`GEMINI.md` / `README.md` に記載されたバージョン情報が、実際の出典ファイルと乖離していたため実態に合わせて修正します。

Closes #1841

## 変更内容

### GEMINI.md（`## 2. 技術スタック & 開発環境`）

| 項目 | 変更前 | 変更後 | 出典 |
|---|---|---|---|
| Ruby | 4.0.1 | **4.0.3** | `.tool-versions:2`, `Gemfile:6` |
| Node.js | 24.14.0 | **24.15.0** | `.tool-versions:1` |
| pnpm | 10.28.2 | **10.33.2** | `package.json:30` |
| MySQL | 8.0/9.6 | **9.7** | `docker-compose.yml:39` |
| Bootstrap | 5.3.7 | **5.3.8** | `package.json:11` |

再発防止として、各バージョンの出典ファイルを明記する一文を追加しました。

### README.md（`## 🛠 技術スタック`）

| 項目 | 変更前 | 変更後 | 出典 |
|---|---|---|---|
| Ruby | 3.4.5 | **4.0.3** | `.tool-versions:2`, `Gemfile:6` |
| Rails | 8.0.0 | **8.1.0** | `Gemfile:9` |
| データベース | MySQL 8.0 | **MySQL 9.7** | `docker-compose.yml:39` |
| Bootstrap | 5.3.7 | **5.3.8** | `package.json:11` |

あわせて前提条件の記述を「MySQL クライアントライブラリ 8.0」と明記しました。`brew install mysql@8.0` は mysql2 gem のビルド用クライアントライブラリの指定であり値自体は正しいのですが、技術スタック節を 9.7 に直した結果、同一ファイル内で矛盾して見えるようになったためです。数値は変更せず、何のバージョンかを補足しています。

## Issue 記載との差分

Issue 起票時から `main` が進んでいるため、着手時点の実態に合わせて 2 点調整しています。

1. **`CLAUDE.md` は変更していません。** 現在の `main` では既に「バージョンの正」節で出典を示し数値を書かない方式に移行済みで、Issue が指す `CLAUDE.md:11「Ruby: 4.0.1」` は現存しません。
2. **Issue の表に無い MySQL の乖離を追加で修正しました。** ドキュメントは `8.0` / `8.0.9.6`、実態は `docker-compose.yml` の `mysql:9.7` です。Issue の修正方針「単一の出典に揃える」に含まれると判断しました。

なお Rails は `Gemfile` が `~> 8.1.0`（悲観的制約）、`Gemfile.lock` の解決値は `8.1.3` です。パッチ更新のたびにドキュメント修正が発生するのを避けるため、Issue の指定どおり制約側の `8.1.0` を記載しています。

## 動作確認

- 出典ファイルとドキュメント記載値を機械的に突合する検証を実施し、**11 項目全件の一致**を確認しました（`Gemfile` と `.tool-versions` の Ruby 整合も確認）
- 3 ファイル全体を grep し、未修正のバージョン数値が残っていないことを確認しました

`bundle exec rubocop` / `bundle exec rspec` は未実行です。ローカルの Ruby が 3.4.6 で `Gemfile` の要求する 4.0.3 が未インストールのため起動できませんでした。本 PR は `.md` 2 ファイルのみの変更で Ruby / 設定ファイルを一切変更していないため結果に影響しません。CI での実行結果をご確認ください。

## スコープ外

- 検索エンジン（Elasticsearch → OpenSearch）の記述見直し（Issue に「別 Issue で扱う」と明記あり。現 `main` では既に OpenSearch 記述に更新済み）
- バージョン乖離を検出する CI チェックの追加

## 別途ご確認いただきたい点

`.github/workflows/ruby.yml:51` のステップ名が `Use Node.js 22.19.0` なのに `node-version: 24.15.0` を指定しており、同種の表記乖離があります。本 Issue のスコープ外のため本 PR では対応していません。


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 216917,
          "cache_creation_input_tokens": 216917,
          "cache_read_input_tokens": 2951150,
          "input_tokens": 73,
          "model": "claude-opus-5",
          "output_tokens": 30809,
          "total_context_tokens": 3198949,
          "turns": 39
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 216917,
          "cache_creation_input_tokens": 216917,
          "cache_read_input_tokens": 2951150,
          "input_tokens": 73,
          "kind": "main",
          "model": "claude-opus-5",
          "name": "main",
          "output_tokens": 30809,
          "total_context_tokens": 3198949,
          "turns": 39
        }
      ],
      "recorded_at": "2026-07-26T08:47:24Z",
      "sha": "ffd3e409082ceab967b88596ec958fca5ea3d1f3",
      "subject": "ドキュメントのバージョン情報を出典と一致させる",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 216917,
        "cache_creation_input_tokens": 216917,
        "cache_read_input_tokens": 2951150,
        "input_tokens": 73,
        "output_tokens": 30809,
        "total_context_tokens": 3198949,
        "turns": 39
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "504986212b3cf553fd7724adbe10d3975f0bbbac",
      "status": "unmetered",
      "subject": "README の MySQL クライアントライブラリの説明を明確化",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "fix/1841-doc-version-sync",
    "number": 1872
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 2,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 216917,
    "cache_creation_input_tokens": 216917,
    "cache_read_input_tokens": 2951150,
    "input_tokens": 73,
    "output_tokens": 30809,
    "total_context_tokens": 3198949,
    "turns": 39
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 216917,
      "cache_creation_input_tokens": 216917,
      "cache_read_input_tokens": 2951150,
      "input_tokens": 73,
      "model": "claude-opus-5",
      "output_tokens": 30809,
      "total_context_tokens": 3198949,
      "turns": 39
    }
  ],
  "updated_at": "2026-07-26T08:52:37Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 技術スタックのバージョン情報を最新化しました。
  * Ruby、Rails、MySQL、Bootstrap などの対応バージョンを明確にしました。
  * ローカル開発環境の前提条件を更新し、Docker を使わない場合に必要な MySQL クライアントライブラリについて追記しました。
  * 各バージョン情報の正しい参照元を明示しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->