### PR TITLE
Dependabot の auto-merge ワークフローを追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot Auto Merge
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr merge --auto --merge --repo "$GH_REPO" "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 概要

`renovate.json` 側は `automerge` / `platformAutomerge` が設定済みですが、Dependabot 側には auto-merge の仕組みが無く、Dependabot の PR だけが手動マージ待ちで滞留しています。kaki-org/baukis2・kaki-org/taskleaf と同じワークフローを追加します。

## 変更内容

### `.github/workflows/dependabot-auto-merge.yml`（新規）
- Dependabot の PR に GitHub の auto-merge を有効化する
- `dependabot/fetch-metadata` で更新種別を判定し、`version-update:semver-major` は auto-merge しない

`renovate.json` は既に `minor` / `patch` を automerge する設定になっているため変更していません。

## 前提: branch protection

auto-merge は「マージ可能になった時点で自動マージ」する機能のため、required status checks が無いと CI 完了を待たずに即マージされます。本リポジトリは `main` に branch protection が無く、`renovate.json` の `platformAutomerge` が CI を待たずにマージしうる状態でした。そのため本 PR とは別に、`main` ブランチへ以下を設定済みです。

- required status checks: `rspec-job`（`.github/workflows/ruby.yml`）
- strict（base への追従必須）は無効
- required approving reviews は 0 件（レビュー必須にすると auto-merge が永久に待機するため）

## 補足

- **Renovate と Dependabot が両方 `bundler` / `npm` / `github-actions` を見ています。** 同じ更新 PR が両方の bot から重複して作られる状態です。どちらか一方に寄せる整理は本 PR のスコープ外としています。
- baukis2 / taskleaf の既存 `dependabot-auto-merge.yml` は PR タイトルに `major` の文字が含まれるかで判定していますが、Dependabot のタイトルに `major` は入らないため実質 major も auto-merge されます。本 PR では `dependabot/fetch-metadata` を使った公式パターンを採用しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の更新に関するプルリクエストの自動処理を追加しました。
  * メジャーバージョンアップを除き、更新内容を確認したうえで自動的にマージできるようになりました。
  * これにより、互換性の高い依存関係の更新をより迅速に取り込めます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->